### PR TITLE
feat: add newish types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/wanderers-nft/opensea-stream-rs"
 categories = ["web-programming::websocket", "cryptography::cryptocurrencies"]
 keywords = ["opensea", "stream", "nft"]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -279,6 +279,8 @@ pub struct ItemListedData {
     /// Creator of the listing.
     #[serde(with = "address_fromjson")]
     pub maker: Address,
+    /// Hash id of the listing.
+    pub order_hash: H256,
     /// Token accepted for payment.
     pub payment_token: PaymentToken,
     /// Number of items on sale. This is always `1` for ERC-721 tokens.
@@ -376,6 +378,11 @@ pub struct ItemCancelledData {
     pub event_timestamp: DateTime<Utc>,
     /// Type of listing. `None` indicates the listing would've been a buyout.
     pub listing_type: Option<ListingType>,
+    /// Creator of the cancellation order.
+    #[serde(with = "address_fromjson")]
+    pub maker: Address,
+    /// Hash id of the listing.
+    pub order_hash: H256,
     /// Token accepted for payment.
     pub payment_token: PaymentToken,
     /// Number of items in listing. This is always `1` for ERC-721 tokens.
@@ -403,6 +410,8 @@ pub struct ItemReceivedOfferData {
     /// Creator of the offer.
     #[serde(with = "address_fromjson")]
     pub maker: Address,
+    /// Hash id of the listing.
+    pub order_hash: H256,
     /// Token offered for payment.
     pub payment_token: PaymentToken,
     /// Number of items on the offer. This is always `1` for ERC-721 tokens.
@@ -431,6 +440,8 @@ pub struct ItemReceivedBidData {
     /// Creator of the bid.
     #[serde(with = "address_fromjson")]
     pub maker: Address,
+    /// Hash id of the listing.
+    pub order_hash: H256,
     /// Token offered for payment.
     pub payment_token: PaymentToken,
     /// Number of items on the offer. This is always `1` for ERC-721 tokens.


### PR DESCRIPTION
This adds order_hash and maker. Order_hash is in particular useful as it allows correlating of events much like the transaction hash, in principle this should allow the recreation of opensea's order-book using this stream.

this commit fixes #4 

Please pull and give it a try I only did some limited testing.

Another note: I also noticed their docs weren't complete, ie bid was missing order_hash in the docs but present in the steam. I pinged opensea about it but I'm not sure when they'll update. Should probably add some sort of job to pull and build latest schema so we know when to update.