### PR TITLE
chore: bump ethers-core to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4.19", features = ["serde"] }
-ethers-core = "1.0.2"
+ethers-core = "2.0.0"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4.19", features = ["serde"] }
-ethers-core = "0.17.0"
+ethers-core = "1.0.2"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -279,6 +279,8 @@ pub struct ItemListedData {
     /// Creator of the listing.
     #[serde(with = "address_fromjson")]
     pub maker: Address,
+    /// Order hash. 
+    pub order_hash: H256,
     /// Token accepted for payment.
     pub payment_token: PaymentToken,
     /// Number of items on sale. This is always `1` for ERC-721 tokens.


### PR DESCRIPTION
Fix transitive dependency issues with other crypto packages 